### PR TITLE
DS-2845: Improve error message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipDimensionReduction
 Type: Package
 Title: Algorithms for dimension reduction
-Version: 1.1.10
+Version: 1.1.11
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Tools for dimension reduction (e.g. principal components analysis,

--- a/tests/testthat/test-multiplecorrespondenceanalysis.R
+++ b/tests/testthat/test-multiplecorrespondenceanalysis.R
@@ -61,4 +61,8 @@ test_that("Filters", {
           expect_equal(all(!is.na(filt.coord[which(fcond),1])), TRUE)
 })
 
-
+test_that("Error",
+{
+    expect_error(suppressWarnings(MultipleCorrespondenceAnalysis(~Q2 + Q3, data = cola)), fixed = TRUE,
+        "Could not perform Multiple Correspondence Analysis. Input data reduces to 1 standard coordinate. Try including additional variables in the analysis.")
+})


### PR DESCRIPTION
The bug reported here is due to an error in `ca::mjca` because the data reduces to a single standard coordinate, which causes problems with matrices and dimensions. I've tried to make the error message more informative, but its also possible that errors are caused by other types of problems. However, in any case, we probably don't want to report the raw error message given by `ca::mjca`